### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/clear_formatting.js
+++ b/clear_formatting.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_dd_format = (hookName, args, cb) => {
   args.content += eejs.require('ep_clear_formatting/templates/clear_formatting_menu.ejs');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_clear_formatting",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "keywords": [
     "clear",
     "formatting"


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.